### PR TITLE
Increased maximum version in config files

### DIFF
--- a/test/config/ext-test_config_default.jsonp
+++ b/test/config/ext-test_config_default.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "ext-test_config_default",

--- a/test/config/ext-test_config_default.jsonp
+++ b/test/config/ext-test_config_default.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "ext-test_config_default",


### PR DESCRIPTION
Hint:
Make sure that the installer also adapts the default configuration file which is used for level 4 configuration, to:
```
	"Maximum_version" : "1.99.0",
	"Minimum_version" : "0.6.0",
```